### PR TITLE
feature/22-44

### DIFF
--- a/packages/client/src/hoc/withAuth.tsx
+++ b/packages/client/src/hoc/withAuth.tsx
@@ -3,12 +3,23 @@ import { Navigate } from 'react-router-dom'
 
 export default function WithAuth<P extends object>(
   PrivateComponent: ComponentType<P>,
-  redirectTo = '/signin'
+  redirectTo = '/signin',
+  invertRule = false
 ): React.ComponentType | any {
   return function HOC(props: any) {
-    const login = Math.random() < 0.5
+    let userId = localStorage.getItem('userId')
 
-    return login ? (
+    if (userId === '0') {
+      userId = null
+    }
+
+    let isLogin = userId !== null
+
+    if (invertRule) {
+      isLogin = !isLogin
+    }
+
+    return isLogin ? (
       <PrivateComponent {...props} />
     ) : (
       <Navigate to={redirectTo} />

--- a/packages/client/src/layouts/app/App.test.tsx
+++ b/packages/client/src/layouts/app/App.test.tsx
@@ -15,5 +15,5 @@ test('Example test', async () => {
   )
 
   const dogImages = screen.getAllByRole('link')
-  expect(dogImages).toHaveLength(8)
+  expect(dogImages).toHaveLength(5)
 })

--- a/packages/client/src/layouts/app/App.tsx
+++ b/packages/client/src/layouts/app/App.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react'
 import { Container, Navbar, Nav } from 'react-bootstrap'
 import { NavLink, Outlet } from 'react-router-dom'
 import { LINKS } from './constants'
@@ -11,6 +12,10 @@ const App = () => {
     userId = null
   }
 
+  const availableLinks = useMemo(() => LINKS.filter(link => !((link.showUnregOnly && userId !== null) ||
+  (link.private && userId === null))),
+  [userId])
+
   return (
     <div className="App">
       <Navbar fixed="top" bg="light">
@@ -20,20 +25,11 @@ const App = () => {
           </NavLink>
           <Navbar.Collapse id="basic-navbar-nav">
             <Nav className="justify-content-end flex-grow-1">
-              {LINKS.map(link => {
-                if (
-                  (link.showUnregOnly && userId !== null) ||
-                  (link.private && userId === null)
-                ) {
-                  return
-                }
-
-                return (
+              {availableLinks.map(link => (
                   <NavLink className="nav-link" key={link.path} to={link.path}>
                     {link.title}
                   </NavLink>
-                )
-              })}
+              ))}
             </Nav>
           </Navbar.Collapse>
         </Container>

--- a/packages/client/src/layouts/app/App.tsx
+++ b/packages/client/src/layouts/app/App.tsx
@@ -1,28 +1,45 @@
-import { Outlet } from 'react-router-dom'
 import { Container, Navbar, Nav } from 'react-bootstrap'
-import { NavLink } from 'react-router-dom'
-
+import { NavLink, Outlet } from 'react-router-dom'
 import { LINKS } from './constants'
 
-import "./app.scss"
+import './app.scss'
 
-function App() {
+const App = () => {
+  let userId = localStorage.getItem('userId')
+
+  if (userId === '0') {
+    userId = null
+  }
+
   return (
     <div className="App">
       <Navbar fixed="top" bg="light">
         <Container>
-          <NavLink className="navbar-brand" to="/">Крокодил</NavLink>
+          <NavLink className="navbar-brand" to="/">
+            Крокодил
+          </NavLink>
           <Navbar.Collapse id="basic-navbar-nav">
             <Nav className="justify-content-end flex-grow-1">
-              {LINKS.map(link => (
-                <NavLink className="nav-link" key={link.path} to={link.path}>{link.title}</NavLink>
-              ))}
+              {LINKS.map(link => {
+                if (
+                  (link.showUnregOnly && userId !== null) ||
+                  (link.private && userId === null)
+                ) {
+                  return
+                }
+
+                return (
+                  <NavLink className="nav-link" key={link.path} to={link.path}>
+                    {link.title}
+                  </NavLink>
+                )
+              })}
             </Nav>
           </Navbar.Collapse>
         </Container>
       </Navbar>
       <Container>
-        <Outlet/>
+        <Outlet />
       </Container>
     </div>
   )

--- a/packages/client/src/layouts/app/constants.ts
+++ b/packages/client/src/layouts/app/constants.ts
@@ -1,9 +1,9 @@
 export const LINKS = [
-  { title: 'Вход', path: 'signin' },
+  { title: 'Вход', path: 'signin', showUnregOnly: true },
+  { title: 'Выход', path: 'signout', private: true },
   { title: 'Регистрация', path: 'signup' },
-  { title: 'Выход', path: 'signout' },
-  { title: 'Профиль', path: 'profile' },
-  { title: 'Игра', path: 'game' },
+  { title: 'Профиль', path: 'profile', private: true },
+  { title: 'Игра', path: 'game', private: true },
   { title: 'Лидеры', path: 'leaders' },
   { title: 'Форум', path: 'forum' },
 ]

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -9,6 +9,7 @@ import {
   StartPage,
   ErrorPage,
   Profile,
+  PrivateProfile,
   Login,
   LeaderBoard,
   leaderBoardLoader,
@@ -29,6 +30,7 @@ export enum Routes {
   Logout = 'signout',
   Game = 'game',
   Profile = 'profile',
+  ProfileId = 'profile/:profileId',
   Leaderboard = 'leaders',
   Forum = 'forum',
   E404 = '404',
@@ -87,6 +89,15 @@ const router = createBrowserRouter([
       },
       {
         path: Routes.Profile,
+        element: (
+          <Page title="Крокодил - Профиль">
+            <PrivateProfile />
+          </Page>
+        ),
+      },
+      {
+        path: Routes.ProfileId,
+        loader: undefined,
         element: (
           <Page title="Крокодил - Профиль">
             <Profile />

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -4,7 +4,21 @@ import ReactDOM from 'react-dom/client'
 import { createBrowserRouter, redirect, RouterProvider } from 'react-router-dom'
 // components
 import App from './layouts/app/App'
-import { StartPage, ErrorPage, Profile, Login, LeaderBoard, leaderBoardLoader, Game, Forum, Registration } from './pages'
+
+import {
+  StartPage,
+  ErrorPage,
+  Profile,
+  Login,
+  LeaderBoard,
+  leaderBoardLoader,
+  Game,
+  Forum,
+  Registration,
+  Page,
+} from './pages'
+
+import api from './api'
 // styles
 import 'bootstrap/dist/css/bootstrap.min.css'
 
@@ -21,46 +35,80 @@ export enum Routes {
   E500 = '500',
 }
 
-// приватные страницы
-// const LoginPage = WithAuth(Login, `/${Routes.Game}`)
-// const ProfilePage = WithAuth(Profile, `/${Routes.Login}`)
-// const GamePage = WithAuth(Game, `/${Routes.Login}`)
+const userLoader = async () => {
+  let { id } = await api.auth.user()
+
+  if (typeof id === 'undefined') {
+    id = 0
+  }
+
+  localStorage.setItem('userId', String(id))
+  return null
+}
 
 const router = createBrowserRouter([
   {
     path: Routes.Index,
     element: <App />,
     errorElement: <ErrorPage />,
-    loader: undefined,
+    loader: userLoader,
     children: [
       {
         index: true,
-        element: <StartPage />,
+        element: (
+          <Page title="Крокодил - Главная страница">
+            <StartPage />
+          </Page>
+        ),
       },
       {
         path: Routes.Login,
-        element: <Login />,
+        element: (
+          <Page title="Крокодил - Вход">
+            <Login />
+          </Page>
+        ),
       },
       {
         path: Routes.Game,
-        element: <Game />,
+        element: (
+          <Page title="Крокодил - Игра">
+            <Game />
+          </Page>
+        ),
       },
       {
         path: Routes.Register,
-        element: <Registration />,
+        element: (
+          <Page title="Крокодил - Регистрация">
+            <Registration />
+          </Page>
+        ),
       },
       {
         path: Routes.Profile,
-        element: <Profile />,
+        element: (
+          <Page title="Крокодил - Профиль">
+            <Profile />
+          </Page>
+        ),
       },
       {
         path: Routes.Leaderboard,
         loader: leaderBoardLoader,
-        element: <LeaderBoard />,
+        element: (
+          <Page title="Крокодил - Лидеры">
+            <LeaderBoard />
+          </Page>
+        ),
       },
       {
         path: Routes.Forum,
-        element: <Forum />,
+        element: (
+          <Page title="Крокодил - Форум">
+            <Forum />
+          </Page>
+        ),
       },
       {
         path: Routes.Logout,
@@ -73,23 +121,22 @@ const router = createBrowserRouter([
   },
   {
     path: Routes.E404,
-    element: <ErrorPage />,
+    element: (
+      <Page title="Ошибка - 404">
+        <ErrorPage />
+      </Page>
+    ),
   },
   {
     path: Routes.E500,
-    element: <ErrorPage />,
+    element: (
+      <Page title="Ошибка - 500">
+        <ErrorPage />
+      </Page>
+    ),
   },
 ])
 
-import api from './api';
-
-api.auth.signIn({
-  login:"ZinovNA",
-  password:"123qwertY@"
-}).then(v=>{
-  console.log('vvv',v);
-  api.auth.logOut()
-})
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/packages/client/src/pages/index.ts
+++ b/packages/client/src/pages/index.ts
@@ -6,6 +6,7 @@ import StartPage from './startPage/StartPage';
 import ErrorPage from './error/Error';
 import LeaderBoard, {leaderBoardLoader} from './leaderBoard/LeaderBoard';
 import Forum from './forum/Forum';
+import Page from './page/Page'
 
 export {
   Registration,
@@ -17,4 +18,5 @@ export {
   leaderBoardLoader,
   Game,
   Forum,
+  Page,
 }

--- a/packages/client/src/pages/index.ts
+++ b/packages/client/src/pages/index.ts
@@ -1,4 +1,4 @@
-import Profile from './profile/Profile';
+import Profile, {PrivateProfile} from './profile/Profile';
 import Game from './game/Game'
 import Registration from './registration/Registration';
 import Login from './login/Login';
@@ -13,6 +13,7 @@ export {
   StartPage,
   ErrorPage,
   Profile,
+  PrivateProfile,
   Login,
   LeaderBoard,
   leaderBoardLoader,

--- a/packages/client/src/pages/login/Login.tsx
+++ b/packages/client/src/pages/login/Login.tsx
@@ -3,6 +3,7 @@ import { useForm } from 'react-hook-form'
 // Router
 import { NavLink } from 'react-router-dom'
 import { Routes } from '../../main'
+import WithAuth from '../../hoc/withAuth'
 // interfaces
 import { LoginData } from '../../types/interfaces'
 // components
@@ -69,4 +70,4 @@ const Login = () => {
   )
 }
 
-export default Login
+export default WithAuth(Login, '/game', true)

--- a/packages/client/src/pages/page/Page.tsx
+++ b/packages/client/src/pages/page/Page.tsx
@@ -1,0 +1,10 @@
+import { useEffect } from 'react'
+
+const Page = (props: any) => {
+  useEffect(() => {
+    document.title = props.title || ''
+  }, [props.title])
+  return props.children
+}
+
+export default Page

--- a/packages/client/src/pages/profile/Profile.tsx
+++ b/packages/client/src/pages/profile/Profile.tsx
@@ -13,7 +13,7 @@ enum Pages {
   Edit = 'ProfileEdit',
 }
 
-export const ProfileComp = () => {
+const Profile = () => {
   const [fields, setFields] = useState<ProfileParams>({})
   const [page, setPage] = useState(Pages.Show)
 
@@ -63,4 +63,5 @@ export const ProfileComp = () => {
   </Container>
 }
 
-export default withAuth(ProfileComp)
+export const PrivateProfile = withAuth(Profile)
+export default Profile

--- a/packages/client/src/pages/profile/Profile.tsx
+++ b/packages/client/src/pages/profile/Profile.tsx
@@ -3,6 +3,8 @@ import { Button, Card, Row, Col, Container } from 'react-bootstrap'
 
 import { Avatar, FormEdit, FormShow, FormPassword } from './components'
 
+import withAuth from '../../hoc/withAuth'
+
 import "./profile.scss"
 
 enum Pages {
@@ -11,7 +13,7 @@ enum Pages {
   Edit = 'ProfileEdit',
 }
 
-const Profile = () => {
+export const ProfileComp = () => {
   const [fields, setFields] = useState<ProfileParams>({})
   const [page, setPage] = useState(Pages.Show)
 
@@ -61,4 +63,4 @@ const Profile = () => {
   </Container>
 }
 
-export default Profile
+export default withAuth(ProfileComp)

--- a/packages/client/src/pages/profile/profile.test.tsx
+++ b/packages/client/src/pages/profile/profile.test.tsx
@@ -1,4 +1,4 @@
-import ProfilePage from './Profile'
+import { ProfileComp } from './Profile'
 import { render, screen } from '@testing-library/react'
 
 const appContent = 'Профиль'
@@ -9,6 +9,6 @@ global.fetch = jest.fn(() =>
 )
 
 test('Example test', async () => {
-  render(<ProfilePage />)
+  render(<ProfileComp />)
   expect(screen.getByText(appContent)).toBeDefined()
 })

--- a/packages/client/src/pages/profile/profile.test.tsx
+++ b/packages/client/src/pages/profile/profile.test.tsx
@@ -1,4 +1,4 @@
-import { ProfileComp } from './Profile'
+import Profile  from './Profile'
 import { render, screen } from '@testing-library/react'
 
 const appContent = 'Профиль'
@@ -9,6 +9,6 @@ global.fetch = jest.fn(() =>
 )
 
 test('Example test', async () => {
-  render(<ProfileComp />)
+  render(<Profile />)
   expect(screen.getByText(appContent)).toBeDefined()
 })


### PR DESCRIPTION
В роутере добавлена возможность, присваивать страницам заголовки (title). 
Реализована следующая логика:
Зарегистрированный пользователь в главном меню имеет ссылки: "Выход", "Регистрация", "Профиль", "Игра", "Лидеры", "Форум"
Незарегистрированный: "Вход", "Регистрация", "Лидеры", "Форум"

![image](https://user-images.githubusercontent.com/76275676/218806128-a41806ae-507b-4e33-acb9-c6ce2cc8e1bf.png)

Если пользователь не зарегистрирован и пытается зайти на одну из приватных страниц (игра или профиль) то он попадает на страницу входа.
Кроме того, если уже зарегистрированный пользователь попытается перейти на страницу регистрации, он попадает на страницу игры